### PR TITLE
Allow newer PHP versions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.0|~8.2.0|~8.3.0|~8.4.0",
+        "php": "^8.1",
         "blade-ui-kit/blade-icons": "^1.6",
         "illuminate/support": "^9.0|^10.0|^11.0|^12.0"
     },


### PR DESCRIPTION
This permits PHP 8.5.